### PR TITLE
solved typerror cant read length of undefined in mainsection.tsx 39:64

### DIFF
--- a/src/MainSection.tsx
+++ b/src/MainSection.tsx
@@ -36,7 +36,7 @@ const MainSection = () => {
         `${API_URL}?query=${searchInput.current?.value}&page=${page}&per_page=${Image_count}&client_id=${process.env.REACT_APP_UNSPLASH_API_KEY}`
       );
       const json = await data.json();
-      results = json?.results;
+      results = (json.results)?json.results:[];
 
       if (results < 28) setLastPage(true);
 
@@ -61,7 +61,7 @@ const MainSection = () => {
         `${API_URL}?query=${searchInput.current?.value}&page=${page}&per_page=${Image_count}&client_id=${process.env.REACT_APP_UNSPLASH_API_KEY}`
       );
       const json = await data.json();
-      results = json?.results;
+      results = (json.results)?json.results:[];
 
       if (results < 28) setLastPage(true);
 


### PR DESCRIPTION
**What does this PR do?**
when an api error occures the result variable will get the value undefined added a ternary operator that ensures that the error pages are loaded properly 

**Related Issue(s)**
when an api error occurs it does not load the error page properly it shows a typeerror


**Changes**
added ternary operator that ensures that the result variable in mainsection.tsx : 39:64 gets an empty when its undefined

**Screenshots or GIFs (if applicable)**
![Screenshot from 2023-10-22 14-01-03](https://github.com/Vijaykv5/SnapGrid/assets/43089951/9228968e-b7b0-4e02-8f66-c3d92423ad60)
![Screenshot from 2023-10-22 14-02-10](https://github.com/Vijaykv5/SnapGrid/assets/43089951/defd2c3a-5f11-4e5e-a98c-c7702f50e3be)


**Checklist**
- [x ] I have read and followed the [contributing guidelines](../CONTRIBUTING.md).
- [x ] My code follows the project's coding style and conventions.
- [x ] I have added unit tests (if applicable) to ensure the code works as expected.
- [x ] I have updated the project documentation (if necessary).

**Additional Comments**
Add any additional comments, context, or information about this PR.

**By submitting this PR, I confirm that:**
- [x ] I have reviewed my code and believe it is ready for merging.
- [x ] I understand that this PR may be subject to review and changes.
- [x ] I agree to abide by the code of conduct and contributing guidelines of this project.
